### PR TITLE
Corrected L1 formula

### DIFF
--- a/code/loss_functions.py
+++ b/code/loss_functions.py
@@ -41,7 +41,7 @@ def KLDivergence(yHat, y):
 
 
 def L1(yHat, y):
-    return np.sum(np.absolute(yHat - y))
+    return np.sum(np.absolute(yHat - y)) / y.size
 
 
 def L2(yHat, y):


### PR DESCRIPTION
The L1 formula should be divided by its size after calculating sum