### PR TITLE
Fix: loss_functions.py --> Hinge Loss

### DIFF
--- a/code/loss_functions.py
+++ b/code/loss_functions.py
@@ -24,7 +24,7 @@ def Dice(yHat, y):
 
 
 def Hinge(yHat, y):
-    return np.max(0, 1 - yHat * y)
+    return np.max(0, y - (1-2*y)*yHat)
 
 
 def Huber(yHat, y, delta=1.):


### PR DESCRIPTION
In the documentation, y is binary (={0, 1}). The Hinge loss presented was the Hinge loss corresponding to a {-1, +1}.
I think the error came from a bad Copy-Paste from Wikipedia (https://en.wikipedia.org/wiki/Hinge_loss) where they use a {-1, +1} notation for classes.
In the original version of the code, you can even notice that Hinge Loss == 1 for y = 0 NO MATTER WHAT yhat is !